### PR TITLE
FastLEDのバージョンを3.6.0に固定

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,7 @@ board = esp32-s3-devkitc-1
 framework = arduino
 monitor_speed = 115200
 lib_deps = 
-	fastled/FastLED
+	fastled/FastLED@3.6.0
 	tinyu-zhao/INA3221
 	mathertel/OneButton @ ^2.5.0
 


### PR DESCRIPTION
バージョン指定無しで入る最新の3.9系では参照エラーでビルドが失敗する為、FastLEDのバージョンを3.6.0に固定したいです。